### PR TITLE
docs: add security and design references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This skill focuses on general Java standards that are broadly reusable across pr
 2. code style, object/value handling, collections, concurrency, and control flow
 3. exceptions, error-code boundaries, and logging rules
 4. unit testing expectations and review signals
-5. MySQL, SQL, and ORM mapping constraints
-6. engineering structure vocabulary and documentation signals
+5. security review signals for common Java application risks
+6. MySQL, SQL, and ORM mapping constraints
+7. engineering structure vocabulary and design-documentation signals
 
 It is intentionally separate from project-specific layered backend rules. If a repository also needs strict layering constraints such as `Controller -> Service -> BizMapper -> Mapper`, pair this skill with `java-backend-standards`.
 
@@ -29,10 +30,12 @@ It is intentionally separate from project-specific layered backend rules. If a r
 └── references/
     ├── checklist.md
     ├── code-and-runtime-rules.md
+    ├── design-and-architecture.md
     ├── engineering-structure.md
     ├── exceptions-and-logging.md
     ├── mysql-sql-orm.md
     ├── naming-and-constants.md
+    ├── security.md
     └── unit-testing.md
 ```
 
@@ -42,8 +45,10 @@ It is intentionally separate from project-specific layered backend rules. If a r
 - `references/code-and-runtime-rules.md`: style, object/value rules, collections, concurrency, control flow
 - `references/exceptions-and-logging.md`: error-code boundaries, exception handling, logging rules
 - `references/unit-testing.md`: unit-test expectations and review signals
+- `references/security.md`: security review signals for input validation, exposure, redirects, and abuse controls
 - `references/mysql-sql-orm.md`: MySQL, SQL, and ORM mapping guidance
-- `references/engineering-structure.md`: model/layer vocabulary, documentation and design-review signals
+- `references/engineering-structure.md`: model/layer vocabulary and documentation expectations
+- `references/design-and-architecture.md`: architecture-review and design-documentation signals
 - `references/checklist.md`: flat review checklist for quick passes
 
 ## Usage

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,8 +10,9 @@
 2. 代码风格、对象和值处理、集合、并发、控制流
 3. 异常边界、错误码、日志规则
 4. 单元测试要求和 review 信号
-5. MySQL、SQL、ORM 映射约束
-6. 工程结构术语、文档与设计信号
+5. 常见 Java 应用安全 review 信号
+6. MySQL、SQL、ORM 映射约束
+7. 工程结构术语、设计与文档信号
 
 它刻意不承载项目专属的后端分层约束。若某个项目还要求严格的 `Controller -> Service -> BizMapper -> Mapper` 调用链，应与 `java-backend-standards` 一起使用。
 
@@ -27,10 +28,12 @@
 └── references/
     ├── checklist.md
     ├── code-and-runtime-rules.md
+    ├── design-and-architecture.md
     ├── engineering-structure.md
     ├── exceptions-and-logging.md
     ├── mysql-sql-orm.md
     ├── naming-and-constants.md
+    ├── security.md
     └── unit-testing.md
 ```
 
@@ -40,8 +43,10 @@
 - `references/code-and-runtime-rules.md`：代码风格、对象/值规则、集合、并发、控制流
 - `references/exceptions-and-logging.md`：错误码边界、异常处理、日志规则
 - `references/unit-testing.md`：单元测试要求与 review 信号
+- `references/security.md`：输入校验、数据暴露、重定向和滥用防护等安全 review 信号
 - `references/mysql-sql-orm.md`：MySQL、SQL、ORM 映射规范
-- `references/engineering-structure.md`：模型/分层术语、文档与设计评审信号
+- `references/engineering-structure.md`：模型/分层术语与文档要求
+- `references/design-and-architecture.md`：架构评审和设计文档信号
 - `references/checklist.md`：快速 review 检查单
 
 ## 使用方式

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: java-general-standards
-description: Apply general Java coding standards for refactor and code review tasks. Use when requests involve naming, constants, enums, code style, exceptions, logging, unit tests, collections, concurrency, control flow, MySQL/SQL/ORM rules, or general engineering structure in Java projects.
+description: Apply general Java coding standards for refactor and code review tasks. Use when requests involve naming, constants, enums, code style, exceptions, logging, unit tests, collections, concurrency, control flow, security review signals, MySQL/SQL/ORM rules, or design and architecture documentation in Java projects.
 ---
 
 # Java General Standards
@@ -14,8 +14,10 @@ This skill is for:
 - code style and runtime rules
 - exceptions and logging
 - unit testing
+- security review signals
 - MySQL / SQL / ORM rules
 - engineering structure vocabulary
+- design and architecture documentation
 
 This skill is not for project-specific layering rules such as `Controller -> Service -> BizMapper -> Mapper`. Use `java-backend-standards` for those constraints.
 
@@ -39,10 +41,14 @@ This skill is not for project-specific layering rules such as `Controller -> Ser
   `references/exceptions-and-logging.md`
 - Unit test rules:
   `references/unit-testing.md`
+- Security review signals:
+  `references/security.md`
 - MySQL, SQL, ORM mapping:
   `references/mysql-sql-orm.md`
 - Engineering structure vocabulary:
   `references/engineering-structure.md`
+- Design and architecture documentation:
+  `references/design-and-architecture.md`
 - Fast review pass:
   `references/checklist.md`
 
@@ -54,6 +60,7 @@ This skill is not for project-specific layering rules such as `Controller -> Ser
 - No `System.out`, `System.err`, or `printStackTrace()` in production code.
 - Exceptions are not used for normal control flow.
 - Error codes are separated from user-facing messages.
+- External input is validated and sensitive output is protected.
 - Critical changes include maintainable unit tests.
 - SQL avoids unsafe interpolation and avoids `select *`.
 - ORM mappings are explicit where field/property conventions differ.

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Java General Standards"
   short_description: "Apply general Java coding rules"
-  default_prompt: "Use $java-general-standards to review or refactor Java code against general naming, exception, logging, unit test, MySQL/SQL/ORM, and engineering structure rules."
+  default_prompt: "Use $java-general-standards to review or refactor Java code against general naming, code style, exception, logging, unit test, security, MySQL/SQL/ORM, and design documentation rules."

--- a/references/checklist.md
+++ b/references/checklist.md
@@ -14,6 +14,10 @@
 - [ ] Error codes are separated from user-facing messages.
 - [ ] Critical changes include unit tests or an explicit reason they do not.
 - [ ] Tests are automatic, independent, and repeatable.
+- [ ] Personal or tenant-scoped data paths enforce permission checks.
+- [ ] Sensitive data is masked or filtered before display and logging.
+- [ ] External input is validated before driving SQL, redirects, regex, shell, or resource-heavy logic.
+- [ ] HTML output and redirect targets are handled with explicit safety controls.
 - [ ] Collection code avoids unsafe mutation patterns and fixed-size view misuse.
 - [ ] Concurrency code does not create unmanaged threads or leak `ThreadLocal` state.
 - [ ] SQL does not use `select *`.
@@ -21,3 +25,4 @@
 - [ ] Multi-table SQL qualifies columns with aliases.
 - [ ] Pagination code short-circuits when `count == 0`.
 - [ ] ORM mappings are explicit when naming conventions differ.
+- [ ] Important state models, data-structure changes, or multi-object flows have matching design documentation when complexity justifies it.

--- a/references/design-and-architecture.md
+++ b/references/design-and-architecture.md
@@ -1,0 +1,47 @@
+# Design And Architecture
+
+## Scope
+
+Use this reference when reviewing:
+- architecture and design documentation quality
+- schema or data-structure changes
+- state-heavy business objects
+- multi-object interaction flows
+- non-functional requirement capture
+
+This file is about design-review signals and documentation expectations, not project-specific layering rules.
+
+## Core Expectations
+
+- Storage schemes and core data structures should be reviewed before rollout when they materially affect long-term system cost or risk.
+- Design documentation should capture boundaries, module relationships, inputs/outputs, and non-functional requirements where the change is large enough to justify it.
+- Agile delivery is not a reason to skip all design artifacts; the goal is to remove waste, not to remove thinking.
+
+## When Extra Design Artifacts Are Justified
+
+- If an object has more than a few meaningful states, document the state model and transitions explicitly.
+- If a feature involves a deeper collaboration chain across multiple components, document the interaction sequence explicitly.
+- If schema, storage, indexing, or long-lived data migration is involved, document the data-structure decisions explicitly.
+- If the model space becomes large or dependency-heavy, document the model relationships clearly enough for future maintainers.
+
+## Design Principles
+
+- Isolate change points instead of letting them leak everywhere.
+- Prefer composition over inheritance unless substitution is clearly valid.
+- Keep classes close to a single responsibility.
+- Depend on abstractions where extension, replacement, or decoupling is a real maintenance concern.
+- Extract shared behavior and shared configuration instead of repeating the same logic across modules.
+
+## Documentation Signals
+
+- Design docs should explain why the chosen structure is acceptable, not just what classes were added.
+- The codebase should retain enough documentation for later maintenance, refactoring, and incident response.
+- Code is part of the documentation surface, but it is not enough to explain deep call chains, state transitions, or non-functional tradeoffs.
+
+## Review Signals
+
+- Schema changes with no durable reasoning about indexing, cardinality, or lifecycle.
+- Stateful workflows with no explicit transition model.
+- Multi-component flows with no sequence-level explanation.
+- Large design changes described only in code diffs with no architectural summary.
+- Repeated logic that should have been extracted into shared modules or abstractions.

--- a/references/engineering-structure.md
+++ b/references/engineering-structure.md
@@ -4,7 +4,7 @@
 
 Use this reference when a task needs shared vocabulary for Java backend model roles or common application layering.
 
-This file is intentionally generic. Project-specific layering rules belong in project-specific skills.
+This file is intentionally generic. Project-specific layering rules belong in project-specific skills, and broader architecture-review guidance belongs in `design-and-architecture.md`.
 
 ## Common Model Terms
 
@@ -39,13 +39,6 @@ This file is intentionally generic. Project-specific layering rules belong in pr
 - Good naming and structure reduce comment burden; comments should explain intent or constraints, not restate obvious code.
 - Delete dead code rather than leaving large commented blocks without clear reason and timestamp.
 - Code is not a complete substitute for architecture or design documentation.
-
-## Design Review Signals
-
-- Review persistent data structures before rollout when the change affects schema, storage, or long-term evolution cost.
-- When object states become non-trivial, capture the state model explicitly.
-- When multiple collaborating objects form a non-trivial flow, capture the sequence explicitly.
-- Architecture and design docs should retain the reasoning about boundaries, dependencies, and non-functional requirements rather than only implementation detail.
 
 ## Review Signals
 

--- a/references/security.md
+++ b/references/security.md
@@ -1,0 +1,46 @@
+# Security
+
+## Scope
+
+Use this reference when reviewing Java application code that:
+- handles user input
+- renders user-visible data
+- performs redirects
+- exposes account- or tenant-scoped data
+- uses platform resources such as SMS, email, payment, or order creation
+
+This file is intentionally focused on application review signals, not full platform or infrastructure security design.
+
+## Access And Data Exposure
+
+- Personal or tenant-scoped pages and actions must enforce permission checks.
+- Sensitive user data should not be displayed in raw form when masking is expected.
+- Do not expose internal error details, stack traces, or raw codes directly as user-facing messages.
+
+## Input Validation
+
+- Validate all externally controlled parameters before they influence query shape, ordering, paging, file access, redirects, or expensive processing.
+- Treat input validation as a security boundary, not just a UX concern.
+- Validate batch-size and page-size style parameters to avoid memory pressure and abusive queries.
+- Be cautious with regex-based validation for attacker-controlled inputs; poorly designed patterns can create ReDoS risk.
+
+## Injection And Output Safety
+
+- SQL parameters must use binding or other explicit safe parameterization. Do not build query conditions with string concatenation.
+- Do not output unescaped or unfiltered user-controlled data into HTML views.
+- Redirect targets supplied from outside the system should pass explicit allowlist validation.
+
+## Request And Action Protection
+
+- State-changing form and AJAX operations should have CSRF protection when the application model requires it.
+- High-cost or sensitive platform actions such as SMS, email, calls, ordering, or payment need anti-replay or abuse controls.
+- User-generated content flows should consider anti-spam, abuse throttling, and content filtering when the product domain requires it.
+
+## Review Signals
+
+- Missing permission checks on user-owned resources.
+- Raw personal data shown in full where masking is expected.
+- Dynamic SQL assembled from request strings.
+- Request parameters directly controlling `order by`, redirect targets, or regex execution.
+- HTML rendering of unsanitized user data.
+- Missing replay or rate controls around costly external actions.


### PR DESCRIPTION
## Summary
- add `security.md` for reusable Java application security review signals
- add `design-and-architecture.md` for architecture and documentation review signals
- update `SKILL.md`, `agents/openai.yaml`, README files, and checklist to route these new references

## Verification
- `git diff --check`
- documentation-only change; no executable tests required

Closes #1